### PR TITLE
Configure production with url and anon key

### DIFF
--- a/src/app/api/admin/blogs/[id]/route.ts
+++ b/src/app/api/admin/blogs/[id]/route.ts
@@ -3,11 +3,11 @@ import { createClient } from '@supabase/supabase-js'
 import { getSupabaseEnv } from '@/lib/env'
 
 function getSupabase() {
-  const { url, serviceKey } = getSupabaseEnv()
-  if (!url || !serviceKey) {
+  const { url, anonKey } = getSupabaseEnv()
+  if (!url || !anonKey) {
     throw new Error('Supabase environment variables are not configured')
   }
-  return createClient(url, serviceKey, {
+  return createClient(url, anonKey, {
     auth: { autoRefreshToken: false, persistSession: false }
   })
 }

--- a/src/app/api/admin/blogs/route.ts
+++ b/src/app/api/admin/blogs/route.ts
@@ -3,15 +3,15 @@ import { createClient } from '@supabase/supabase-js'
 import { getSupabaseEnv } from '@/lib/env'
 
 function getSupabase() {
-  const { url, serviceKey } = getSupabaseEnv()
-  if (!url || !serviceKey) {
+  const { url, anonKey } = getSupabaseEnv()
+  if (!url || !anonKey) {
     console.error('Supabase env missing', {
       hasUrl: !!url,
-      hasServiceKey: !!serviceKey
+      hasAnonKey: !!anonKey
     })
     throw new Error('Supabase environment variables are not configured')
   }
-  return createClient(url, serviceKey, {
+  return createClient(url, anonKey, {
     auth: { autoRefreshToken: false, persistSession: false }
   })
 }

--- a/src/app/api/admin/company/route.ts
+++ b/src/app/api/admin/company/route.ts
@@ -3,11 +3,11 @@ import { createClient } from '@supabase/supabase-js'
 import { getSupabaseEnv } from '@/lib/env'
 
 function getSupabase() {
-  const { url, serviceKey } = getSupabaseEnv()
-  if (!url || !serviceKey) {
+  const { url, anonKey } = getSupabaseEnv()
+  if (!url || !anonKey) {
     throw new Error('Supabase environment variables are not configured')
   }
-  return createClient(url, serviceKey, {
+  return createClient(url, anonKey, {
     auth: { autoRefreshToken: false, persistSession: false }
   })
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -6,13 +6,13 @@ export function getSupabaseAdmin(): SupabaseClient {
   if (cachedClient) return cachedClient
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
-  const serviceRoleKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY) as string
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
 
-  if (!supabaseUrl || !serviceRoleKey) {
-    throw new Error('Supabase admin environment variables are not set')
+  if (!supabaseUrl || !anonKey) {
+    throw new Error('Supabase environment variables are not set')
   }
 
-  cachedClient = createClient(supabaseUrl, serviceRoleKey, {
+  cachedClient = createClient(supabaseUrl, anonKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,


### PR DESCRIPTION
Update Supabase client initialization in admin API routes to use the anonymous key instead of a missing service key.

The application's admin API routes were configured to use a Supabase service role key, but only an anonymous key was available in the environment. This led to "Supabase environment variables are not configured" errors. This PR modifies the Supabase client initialization across relevant admin routes and the server utility to correctly use the anonymous key, enabling the application to function.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bb4b7f4-8ded-4b87-9b76-6589c62e6966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bb4b7f4-8ded-4b87-9b76-6589c62e6966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

